### PR TITLE
Trivial cleanups and modernizations.

### DIFF
--- a/xmille/comp.c
+++ b/xmille/comp.c
@@ -47,7 +47,7 @@ calcmove(void)
 	PLAY		*pp, *op;
 	bool		foundend, canstop, foundlow;
 	int		cango;
-	unsgn int	i, count200, badcount, nummin, nummax, diff;
+	unsigned int	count200, badcount, nummin, nummax, diff;
 	int		curmin, curmax;
 	CARD		safe, oppos;
 	int		valbuf[HAND_SZ], count[NUM_CARDS];
@@ -62,9 +62,9 @@ calcmove(void)
 	foundend = FALSE;
 
 	/* Try for a Coup Forre, and see what we have. */
-	for (i = 0; i < NUM_CARDS; i++)
+	for (int i = 0; i < NUM_CARDS; i++)
 		count[i] = 0;
-	for (i = 0; i < HAND_SZ; i++) {
+	for (int i = 0; i < HAND_SZ; i++) {
 		card = pp->hand[i];
 		switch (card) {
 		  case C_STOP:	case C_CRASH:
@@ -119,7 +119,7 @@ norm:
 #endif
 	if (foundend)
 		foundend = !check_ext(TRUE);
-	for (i = 0; safe && i < HAND_SZ; i++) {
+	for (int i = 0; safe && i < HAND_SZ; i++) {
 		if (is_safety(pp->hand[i])) {
 			if (onecard(op) || (foundend && cango && !canstop)) {
 #ifdef DEBUG
@@ -170,7 +170,7 @@ redoit:
 	nummin = -1;
 	nummax = -1;
 	value = valbuf;
-	for (i = 0; i < HAND_SZ; i++) {
+	for (int i = 0; i < HAND_SZ; i++) {
 		card = pp->hand[i];
 		if (is_safety(card) || playit[i] == (cango != 0)) {
 #ifdef DEBUG

--- a/xmille/curses_ui.c
+++ b/xmille/curses_ui.c
@@ -13,6 +13,8 @@
 #endif
 #define CTRL(x)	(x - 'A' + 1)
 
+#define reg register
+
 WINDOW	*Board, *Miles, *Score;
 
 char	*C_fmt = "%-18.18s";	/* format for printing cards		*/
@@ -59,9 +61,7 @@ ComputerStatus (string)
 	mvaddstr (MOVE_Y + 1, MOVE_X, string);
 }
 
-ComputerCard (type)
-int	type;
-{
+void ComputerCard (int type) {
 	mvprintw (MOVE_Y + 2, MOVE_X, "%16s", C_name[type]);
 }
 
@@ -357,6 +357,13 @@ readch()
 	return c;
 }
 
+// Ancestral code had special debugging for the only for the author based on
+// his UID.  This code was out of date (we have no reason to assume his UID is
+// correct), but we might want to keep the debugging idea protected by that
+// block For now, we'll just leave it memorialized like this.
+static int KenArnoldIsPlayer() {
+	return FALSE;
+}
 
 getmove()
 {
@@ -440,7 +447,7 @@ getmove()
 		  case '\0':		/* and nulls		*/
 			break;
 		  case 'Z':		/* Debug code */
-			if (geteuid() == ARNOLD) {
+			if (KenArnoldIsPlayer()) {
 				if (!Debug && outf == NULL) {
 					char	buf[40];
 over:

--- a/xmille/end.c
+++ b/xmille/end.c
@@ -84,7 +84,7 @@ void
 extrapolate(PLAY *pp)
 {
 
-	reg int		x, num, tot, count;
+	int		x, num, tot, count;
 
 #ifdef NOTYET
 	num = pp - Player;
@@ -131,8 +131,8 @@ void
 undoex(void)
 {
 
-	reg PLAY	*pp;
-	reg int		i;
+	PLAY	*pp;
+	int	i;
 
 	i = 0;
 	for (pp = Player; pp < &Player[2]; pp++) {

--- a/xmille/extern.c
+++ b/xmille/extern.c
@@ -45,7 +45,7 @@ bool	Debug,			/* set if debugging code on		*/
 	Saved;			/* set if game just saved		*/
 
 char	Initstr[100];		/* initial string for error field	*/
-const char	*C_fmt = "%-18.18s",	/* format for printing cards	*/
+const char *const C_fmt = "%-18.18s",	/* format for printing cards	*/
 	*Fromfile = NULL,	/* startup file for game		*/
 	*const _cn[NUM_CARDS] = {	/* Card name buffer		*/
 		"",

--- a/xmille/mille.h
+++ b/xmille/mille.h
@@ -6,7 +6,6 @@
 # include	<stdbool.h>
 # include	<stdlib.h>
 
-# define reg register
 # define TRUE	1
 # define FALSE	0
 
@@ -14,21 +13,12 @@
  * @(#)mille.h	1.1 (Berkeley) 4/1/82
  */
 
+typedef short CARD;
+
 /*
  * Miscellaneous constants
  */
 
-# define	unsgn		unsigned
-# define	CARD		short
-
-# ifdef  vax
-#	define	ARNOLD		78	/* my uid			*/
-# else
-#	define	ARNOLD		24601	/* my uid			*/
-# endif
-
-# define	GURP		28672	/* bad uid			*/
-# define	MAXUSERS	35	/* max # of users for startup	*/
 # define	HAND_SZ		7	/* number of cards in a hand	*/
 # define	DECK_SZ		101	/* number of cards in decks	*/
 # define	NUM_SAFE	4	/* number of saftey cards	*/
@@ -143,10 +133,8 @@ typedef struct {
 # define	nextplay()	(Play = other(Play))
 # define	nextwin(x)	(1 - x)
 # define	opposite(x)	(Opposite[x])
-# define	issafety(x)	(x >= C_GAS_SAFE)
 # define	is_safety(x)	(x >= C_GAS_SAFE)
 
-# define	is_repair(x)	isrepair(x)
 
 /*
  * externals
@@ -154,7 +142,8 @@ typedef struct {
 
 extern bool	Debug, Finished, Next, On_exit, Order, Saved;
 
-extern const char	*C_fmt, *Fromfile;
+extern const char *const C_fmt;
+extern const char	*Fromfile;
 extern const char *const *C_name;
 extern char	Initstr[];
 
@@ -296,7 +285,7 @@ rest(void);
 
 /* types.c */
 bool
-isrepair(CARD card);
+is_repair(CARD card);
 
 int
 safety(CARD card);

--- a/xmille/table.c
+++ b/xmille/table.c
@@ -9,12 +9,10 @@
 void
 main(void)
 {
-
-	reg int	i, j, count;
-
 	printf("   %16s -> %5s %5s %4s %s\n", "Card", "cards", "count", "need", "opposite");
-	for (i = 0; i < NUM_CARDS - 1; i++) {
-		for (j = 0, count = 0; j < DECK_SZ; j++)
+	for (int i = 0; i < NUM_CARDS - 1; i++) {
+		int count = 0;
+		for (int j = 0; j < DECK_SZ; j++)
 			if (Deck[j] == i)
 				count++;
 		printf("%2d %16s -> %5d %5d %4d %s\n", i, C_name[i], Numcards[i], count, Numneed[i], C_name[opposite(i)]);

--- a/xmille/types.c
+++ b/xmille/types.c
@@ -5,7 +5,7 @@
  */
 
 bool
-isrepair(CARD card)
+is_repair(CARD card)
 {
 	return card == C_GAS || card == C_SPARE || card == C_REPAIRS || card == C_INIT;
 }

--- a/xmille/ui.c
+++ b/xmille/ui.c
@@ -9,11 +9,6 @@
 # include	<X11/Xutil.h>
 # include	"gray.bm"
 
-#ifdef CTRL
-# undef CTRL
-#endif
-#define CTRL(x)	(x - 'A' + 1)
-
 # include	"card.h"
 
 struct color colorMap[NUM_COLOR] = {
@@ -25,7 +20,7 @@ struct color colorMap[NUM_COLOR] = {
 	"blue",		0,	0,
 };
 
-char	*C_fmt = "%-18.18s";	/* format for printing cards		*/
+const char *const C_fmt = "%-18.18s";	/* format for printing cards	*/
 char	Initstr[100];		/* initial string for error field	*/
 char	*_cn[NUM_CARDS] = {	/* Card name buffer			*/
 	"",

--- a/xmille/uiXt.c
+++ b/xmille/uiXt.c
@@ -33,11 +33,6 @@
 # include	"cards-svg.h"
 # include	"Mille-res.h"
 
-#ifdef CTRL
-# undef CTRL
-#endif
-#define CTRL(x)	(x - 'A' + 1)
-
 # include	"card.h"
 
 struct color colorMap[NUM_COLOR] = {
@@ -166,17 +161,13 @@ debug (int pos, char *string, int a0, int a1, int a2)
 
 static int  yn_done, yn_answer;
 
-static void YesFunc (w, closure, data)
-    Widget	w;
-    XtPointer	closure, data;
+static void YesFunc (Widget w, XtPointer closure, XtPointer data)
 {
     yn_answer = 1;
     yn_done = 1;
 }
 
-static void NoFunc (w, closure, data)
-    Widget	w;
-    XtPointer	closure, data;
+static void NoFunc (Widget w, XtPointer closure, XtPointer data)
 {
     yn_answer = 0;
     yn_done = 1;
@@ -938,12 +929,11 @@ void
 prboard(void)
 {
 
-	register PLAY	*pp;
-	register int	i, k;
+	PLAY	*pp;
 
-	for (k = 0; k < 2; k++) {
+	for (int k = 0; k < 2; k++) {
 		pp = &Player[k];
-		for (i = 0; i < NUM_SAFE; i++)
+		for (int i = 0; i < NUM_SAFE; i++)
 			if (pp->safety[i] == S_PLAYED) {
 				if (k == 0) {
 					HumanSafety (i + S_CONV, i);
@@ -958,8 +948,8 @@ prboard(void)
 			ComputerBattle (pp->battle);
 			ComputerSpeed (pp->speed);
 		}
-		for (i = C_25; i <= C_200; i++) {
-			register int		end;
+		for (int i = C_25; i <= C_200; i++) {
+			int		end;
 
 			end = pp->nummiles[i];
 			if (k == 0)
@@ -970,7 +960,7 @@ prboard(void)
 	}
 	prscore(TRUE);
 	pp = &Player[PLAYER];
-	for (i = 0; i < HAND_SZ; i++) {
+	for (int i = 0; i < HAND_SZ; i++) {
 		HumanHand (pp->hand[i], i);
 	}
 	DisplayDeck (Topcard - Deck);
@@ -1002,9 +992,8 @@ InScore (int line, int player, char *text)
 void
 prscore(bool for_real)
 {
-
-	register PLAY	*pp;
-	register char	*Score_fmt = "%4d  ";
+	PLAY		*pp;
+	const char Score_fmt[] = "%4d  ";
 	char		buffer[512];
 
 	ComputerDistance (Player[1].mileage);


### PR DESCRIPTION
- Remove aliases for "unsigned" and "register"
- Remove unused macros, including one for Ken Arnold's UID
- Remove "register" keywords (assume the compiler can do register
  assignment)
- Tighter scope for a few loop indexes

This doesn't fix much code in curses_ui.c because that code isn't used,
except for the tweak to remove the global macro that it used.