### PR TITLE
xmille: fix build

### DIFF
--- a/xmille/meson.build
+++ b/xmille/meson.build
@@ -43,7 +43,7 @@ subdir('cards')
 
 make_cards_svg = find_program('make-cards-svg')
 
-cards_files = custom_target('svg-cards',
+cards_files = custom_target('xmille-svg-cards',
 			    depend_files : cards_xmille + ['card-names'],
 			    output : ['cards-svg.c', 'cards-svg.h'],
 			    command : [make_cards_svg, '@OUTPUT0@', '@OUTPUT1@'])


### PR DESCRIPTION
Rename "svg-cards" target to "xmile-svg-cards", preventing an error
message like this on RHEL-8 (meson 0.49.2):

xmille/meson.build:46:0: ERROR:  Tried to create target "svg-cards", but a target of that name already exists.

Signed-off-by: Carlos Santos <unixmania@gmail.com>