### PR TITLE
kcribbage: Make score easier to understand

### DIFF
--- a/kcribbage/CribBoardP.h
+++ b/kcribbage/CribBoardP.h
@@ -51,6 +51,7 @@ typedef struct {
     /* resources */
     XRenderColor    pegColor;
     XRenderColor    holeColor;
+    XRenderColor    trackColor;
     int		    numPegs;
     int		    numCols;
     int		    numRows;

--- a/kcribbage/xt.c
+++ b/kcribbage/xt.c
@@ -278,6 +278,8 @@ UIInitBoard (void)
 {
     resetPegs (compScore, compPegs);
     resetPegs (playScore, playPegs);
+    Message(compName, "My score");
+    Message(playName, "Your score");
 }
 
 void
@@ -475,18 +477,24 @@ void
 UIPrintPeg (int score, BOOLEAN on, int who)
 {
     Widget	w;
+    Widget      l;
     int		*pegs;
     int		i;
+    const char  *label;
 
     if (who == COMPUTER)
     {
 	w = compScore;
+        l = compName;
 	pegs = compPegs;
+        label = "My";
     }
     else
     {
 	w = playScore;
+        l = playName;
 	pegs = playPegs;
+        label = "Your";
     }
 
     if (score <= 0)
@@ -509,6 +517,7 @@ UIPrintPeg (int score, BOOLEAN on, int who)
     }
     pegs[i] = score;
     XkwCribBoardSetPeg (w, i, score - 1);
+    Message(l, "%s score: %d", label, score);
 }
 
 static int  msgLine, msgCol;


### PR DESCRIPTION
Draw a track to make the path of the pegs easier to follow. Also show
a numeric score value.

Closes #7

Signed-off-by: Keith Packard <keithp@keithp.com>