### PR TITLE
Bump Xkw library to version 3.0.0

### DIFF
--- a/Xkw/meson.build
+++ b/Xkw/meson.build
@@ -83,7 +83,7 @@ lib_xkw = library('Xkw',
 		  srcs_xkw, flex_files, bison_files, cards_files,
 		  dependencies: x_libs,
 		  install: true,
-		  version: '2.0.0',
+		  version: '3.0.0',
 		  include_directories: inc)
 
 executable('lodemo',


### PR DESCRIPTION
The ABI and API have changed, so bump the major version.

Signed-off-by: Keith Packard <keithp@keithp.com>