### PR TITLE
kcribbage: Use delays to make play easier to follow

### DIFF
--- a/kcribbage/cribbage.h
+++ b/kcribbage/cribbage.h
@@ -71,6 +71,9 @@ void
 UIWait (void);
 
 void
+UIPause(void);
+
+void
 UIEraseHand (int who);
 
 void

--- a/kcribbage/xt.c
+++ b/kcribbage/xt.c
@@ -684,3 +684,21 @@ UIGetPlayerCard (CARD *hand, int n, char *prompt)
 	msg ("Sorry, I missed that");
     }
 }
+
+static BOOLEAN timer_done;
+
+static void
+timer_proc(XtPointer client_data, XtIntervalId *id)
+{
+    timer_done = TRUE;
+}
+
+void
+UIPause(void)
+{
+    timer_done = FALSE;
+    XtAddTimeOut(1000, timer_proc, NULL);
+    while (!timer_done) {
+        XtProcessEvent(XtIMAll);
+    }
+}


### PR DESCRIPTION
This delays after each play to make the game easier to follow, and
gets rid of most of the '--More--' prompts.

Signed-off-by: Keith Packard <keithp@keithp.com>