### PR TITLE
xmille: Clean up card dragging

### DIFF
--- a/xmille/animate.c
+++ b/xmille/animate.c
@@ -16,6 +16,8 @@ extern int	iscolor;
 extern double scale;
 double	animation_speed = .5;
 
+static int enabled = 1;
+
 static void
 do_animate (int ox, int oy, int dx, int dy);
 
@@ -30,10 +32,16 @@ animate_move (int player, int orig_type, int orig_arg, int dest_type, int dest_a
 {
 	int	ox, oy, dx, dy;
 
-	if (!animation_speed) return;
+	if (!animation_speed || (!enabled && player == PLAYER)) return;
 	compute_position (player, orig_type, orig_arg, &ox, &oy);
 	compute_position (player, dest_type, dest_arg, &dx, &dy);
 	do_animate (ox, oy, dx, dy);
+}
+
+void
+animate_enable(int enable)
+{
+    enabled = enable;
 }
 
 # define abs(x)	((x) < 0 ? -(x) : (x))

--- a/xmille/mille.h
+++ b/xmille/mille.h
@@ -199,6 +199,9 @@ prscore(bool for_real);
 void
 animate_move (int player, int orig_type, int orig_arg, int dest_type, int dest_arg);
 
+void
+animate_enable (int enable);
+
 /* comp.c */
 void
 calcmove(void);

--- a/xmille/uiXt.c
+++ b/xmille/uiXt.c
@@ -537,6 +537,7 @@ InputCallback (Widget w, XtPointer closure, XtPointer data)
     default:
         break;
     case HandActionClick:
+        animate_enable(1);
         if (input->start.w == human_hand)
         {
             Movetype = M_REASONABLE;
@@ -551,12 +552,21 @@ InputCallback (Widget w, XtPointer closure, XtPointer data)
         }
         break;
     case HandActionDrag:
+        if (input->start.w == input->current.w)
+            break;
+        animate_enable(0);
         if (input->start.w == human_hand) {
             if (input->current.w == human_miles ||
                 input->current.w == human_play ||
                 input->current.w == human_safeties)
             {
                 Movetype = M_PLAY;
+                getmove_done = 1;
+                Card_no = input->start.col;
+            }
+            else if (input->current.w == deck_hand)
+            {
+                Movetype = M_DISCARD;
                 getmove_done = 1;
                 Card_no = input->start.col;
             }


### PR DESCRIPTION
Don't animate player card motion after drag.
Ignore drags that start/stop in the same widget.
Allow discards with drags (oops).

closes #35
closes #34 

Signed-off-by: Keith Packard <keithp@keithp.com>