### PR TITLE
xmille: Re-enable 'button 3 discard' operation

### DIFF
--- a/xmille/Mille.ad
+++ b/xmille/Mille.ad
@@ -29,6 +29,9 @@
 	<Key>Tab:	milleDraw()\n\
 	<Key>p:		milleDraw()
 
+*humanHand.translations: #override \n\
+	<Btn3Up>: stop(discard)
+
 *layout.layout: vertical {\
 MenuBarBorderWidth = 1\
 HumanHandBorderWidth = 1\

--- a/xmille/uiXt.c
+++ b/xmille/uiXt.c
@@ -532,6 +532,10 @@ static void
 InputCallback (Widget w, XtPointer closure, XtPointer data)
 {
     HandInputPtr    input = (HandInputPtr) data;
+    String arg = "";
+
+    if (*input->num_params > 0)
+        arg = input->params[0];
 
     switch (input->action) {
     default:
@@ -540,7 +544,10 @@ InputCallback (Widget w, XtPointer closure, XtPointer data)
         animate_enable(1);
         if (input->start.w == human_hand)
         {
-            Movetype = M_REASONABLE;
+            if (strcmp(arg, "discard") == 0)
+                Movetype = M_DISCARD;
+            else
+                Movetype = M_REASONABLE;
             getmove_done = 1;
             Card_no = input->start.col;
         }


### PR DESCRIPTION
Make right-clicking force a discard operation so you don't have to
drag the card to the discard pile.

Closes #39 

Signed-off-by: Keith Packard <keithp@keithp.com>