### PR TITLE
Don't animate after card drag

### DIFF
--- a/kcribbage/xt.c
+++ b/kcribbage/xt.c
@@ -139,8 +139,11 @@ InputCallback (Widget w, XtPointer closure, XtPointer data)
     (void) closure;
 
     switch (input->action) {
+    case HandActionDrag:
+        if (input->start.w == input->current.w)
+            break;
     case HandActionClick:
-        selectedCard = input->current.col;
+        selectedCard = input->start.col;
         cardSelected = True;
         break;
     default:
@@ -560,13 +563,11 @@ int
 UIReadChar (void)
 {
     int	    c;
-    XEvent  event;
 
     ShowCursor ();
     UIRefresh ();
     while (text_in == text_out) {
-	XtNextEvent (&event);
-	XtDispatchEvent (&event);
+	XtProcessEvent (XtIMAll);
     }
     c = textbuf[text_out++];
     if (text_out == text_in)
@@ -685,15 +686,13 @@ UIClearMsg (void)
 int
 UIGetPlayerCard (CARD *hand, int n, char *prompt)
 {
-    XEvent  event;
     for (;;) {
 	msg (prompt);
 	UIRefresh ();
 	cardSelected = False;
 	while (!cardSelected)
 	{
-	    XtNextEvent (&event);
-	    XtDispatchEvent (&event);
+            XtProcessEvent(XtIMAll);
 	}
 	if (0 <= selectedCard && selectedCard < n)
 	{

--- a/kklondike/klondike.c
+++ b/kklondike/klondike.c
@@ -619,6 +619,7 @@ InputCallback (Widget w, XtPointer closure, XtPointer data)
     case HandActionStart:
         break;
     case HandActionClick:
+        CardSetAnimate(True);
         if (stack == &deckStacks[0]) {
             if (!stack->last)
                 ResetDeck ();
@@ -636,6 +637,7 @@ InputCallback (Widget w, XtPointer closure, XtPointer data)
 	}
         break;
     case HandActionDrag:
+        CardSetAnimate(False);
         if (startStack == &deckStacks[0] && stack == &deckStacks[1]) {
             if (startStack->last) {
                 Deal ();

--- a/kspider/spider.c
+++ b/kspider/spider.c
@@ -576,6 +576,7 @@ InputCallback (Widget w, XtPointer closure, XtPointer data)
     case HandActionStart:
         break;
     case HandActionClick:
+        CardSetAnimate(True);
 	if (stack == &deckStack) {
             Deal ();
             CardNextHistory ();
@@ -600,6 +601,7 @@ InputCallback (Widget w, XtPointer closure, XtPointer data)
 	}
         break;
     case HandActionDrag:
+        CardSetAnimate(False);
 	if (startStack == &deckStack || stack == &deckStack)
             break;
 	if (startStack->last)

--- a/ktabby/tabby.c
+++ b/ktabby/tabby.c
@@ -629,12 +629,14 @@ InputCallback (Widget w, XtPointer closure, XtPointer data)
     case HandActionStart:
         break;
     case HandActionClick:
+        CardSetAnimate(True);
         if (stack == &deckStack)
             Deal ();
         else
             Play(stack, NULL, stack);
         break;
     case HandActionDrag:
+        CardSetAnimate(False);
 	if (startStack == &deckStack) {
 	    if (&stackStacks[0] <= stack && stack < &stackStacks[NUM_STACKS])
 		Deal ();

--- a/kthieves/thieves.c
+++ b/kthieves/thieves.c
@@ -519,12 +519,14 @@ InputCallback (Widget w, XtPointer closure, XtPointer data)
     if (!startStack || !stack)
 	return;
 
+    CardSetAnimate(True);
     switch (input->action) {
     case HandActionStart:
 	break;
     case HandActionDrag:
         if (startStack == stack)
             break;
+        CardSetAnimate(False);
         /* fall through */
     case HandActionClick:
 	if (startStack == &deckStack) {

--- a/mc/mc.c
+++ b/mc/mc.c
@@ -498,6 +498,7 @@ InputCallback (Widget w, XtPointer closure, XtPointer data)
             Message(message, "No move.");
             break;
         }
+        CardSetAnimate(True);
         Play(startStack, stack);
         DisplayStacks();
         break;
@@ -508,6 +509,7 @@ InputCallback (Widget w, XtPointer closure, XtPointer data)
             Message(message, "Selected space is empty.");
             break;
         }
+        CardSetAnimate(False);
         Play(startStack, stack);
         DisplayStacks();
 	break;

--- a/slyfox/slyfox.c
+++ b/slyfox/slyfox.c
@@ -784,6 +784,7 @@ StackCallback (Widget w, XtPointer closure, XtPointer data)
 
     to_type = StackType(stack);
 
+    CardSetAnimate(True);
     switch (input->action) {
     case HandActionStart:
         Message(message, "");
@@ -791,6 +792,7 @@ StackCallback (Widget w, XtPointer closure, XtPointer data)
     case HandActionDrag:
         if (startStack == stack)
             break;
+        CardSetAnimate(False);
         /* fall through ... */
     case HandActionClick:
         if (startStack->last)


### PR DESCRIPTION
Presumably dragging cards moves the target stack near the destination,
so doing an animation sequence afterwards is just visual noise. Right
now, this requires informing the animation code separately for each
application, so this patch changes the apps that hadn't received this
update already.

Closes #35 

Signed-off-by: Keith Packard <keithp@keithp.com>