### PR TITLE
kcribbage: Place both scoring tracks in a single board

### DIFF
--- a/kcribbage/CribBoard.c
+++ b/kcribbage/CribBoard.c
@@ -29,16 +29,16 @@
 static XtResource resources[] = {
 #define offset(field) XtOffsetOf(CribBoardRec, cribBoard.field)
     /* {name, class, type, size, offset, default_type, default_addr}, */
-    { XtNpegColor, XtCForeground, XtRRenderColor, sizeof (XRenderColor),
-      offset (pegColor), XtRString, XtDefaultForeground },
+    { XtNpeg1Color, XtCForeground, XtRRenderColor, sizeof (XRenderColor),
+      offset (pegColor[0]), XtRString, XtDefaultForeground },
+    { XtNpeg2Color, XtCForeground, XtRRenderColor, sizeof (XRenderColor),
+      offset (pegColor[1]), XtRString, XtDefaultForeground },
     { XtNholeColor, XtCForeground, XtRRenderColor, sizeof (XRenderColor),
       offset (holeColor), XtRString, XtDefaultForeground },
-    { XtNnumPegs, XtCNumPegs, XtRInt, sizeof (int),
-      offset (numPegs), XtRImmediate, (XtPointer) 2 },
     { XtNnumCols, XtCNumCols, XtRInt, sizeof (int),
       offset (numCols), XtRImmediate, (XtPointer) 30 },
     { XtNnumRows, XtCNumRows, XtRInt, sizeof (int),
-      offset (numRows), XtRImmediate, (XtPointer) 4 },
+      offset (numRows), XtRImmediate, (XtPointer) 8 },
 #undef offset
 };
 
@@ -47,8 +47,9 @@ static XtResource resources[] = {
 #define HOLE_SIZE	3.0
 #define GROUP_SPACE	4.0
 #define PEG_SPACE	10.0
-#define TRACK_WIDTH     1.0
-#define BORDER_WIDTH    12.0
+#define TRACK_WIDTH     10.0
+#define BORDER_WIDTH    30.0
+#define BORDER_HEIGHT   10.0
 
 static inline double
 scaleSize(CribBoardWidget w, double size)
@@ -95,7 +96,7 @@ pegSpace(CribBoardWidget w)
 static inline double
 RowPos(CribBoardWidget w, int row)
 {
-    return (row + 0.5) * pegSpace(w);
+    return (row + 0.5) * pegSpace(w) + (row >> 1) * groupSpace(w);
 }
 
 static inline double
@@ -112,11 +113,17 @@ borderWidth(CribBoardWidget w)
     return scaleSize(w, BORDER_WIDTH);
 }
 
+static inline double
+borderHeight(CribBoardWidget w)
+{
+    return scaleSize(w, BORDER_HEIGHT);
+}
+
 static void
 getSize (CribBoardWidget w, Dimension *widthp, Dimension *heightp)
 {
     *widthp = ColPos(w, w->cribBoard.numCols - 1) + pegSize(w) + borderWidth(w) * 2;
-    *heightp = RowPos(w, w->cribBoard.numRows - 1) + pegSize(w) + borderWidth(w) * 2;
+    *heightp = RowPos(w, w->cribBoard.numRows - 1) + pegSize(w) + borderHeight(w) * 2;
 }
 
 static void
@@ -130,22 +137,20 @@ Initialize (Widget greq, Widget gnew, Arg *args, Cardinal *count)
 {
     CribBoardWidget	req = (CribBoardWidget) greq,
 			new = (CribBoardWidget) gnew;
-    int			i;
+    int			p, i;
 
+    (void) req;
     (void) args;
     (void) count;
     getSize (new, &new->core.width, &new->core.height);
-    new->cribBoard.pegs = Some (int, req->cribBoard.numPegs);
-    for (i = 0; i < req->cribBoard.numPegs; i++)
-	new->cribBoard.pegs[i] = CribBoardUnset;
+    for (p = 0; p < NUM_PLAYER; p++)
+        for (i = 0; i < NUM_PEG; i++)
+            new->cribBoard.pegs[p][i] = CribBoardUnset;
 }
 
 static void
 Destroy (Widget gw)
 {
-    CribBoardWidget    w = (CribBoardWidget) gw;
-
-    Dispose (w->cribBoard.pegs);
 }
 
 /*
@@ -176,24 +181,34 @@ Destroy (Widget gw)
 
 
 static void
-drawPeg (CribBoardWidget w, cairo_t *cr, int value)
+drawPeg (CribBoardWidget w, cairo_t *cr, int player, int value)
 {
-    int	    row, col;
+    int	        row, col;
+    int         subrow;
     double	x, y;
 
     if (value == CribBoardUnset)
 	return;
-    if (value > w->cribBoard.numCols * w->cribBoard.numRows)
-        value = w->cribBoard.numCols * w->cribBoard.numRows;
 
-    row = value / w->cribBoard.numCols;
+    if (value >= w->cribBoard.numCols * (w->cribBoard.numRows/NUM_PLAYER))
+        return;
+
+    if (value < 0)
+        return;
+
+    row = (value / w->cribBoard.numCols);
     col = value % w->cribBoard.numCols;
-    if (row & 1)
+    if (row & 1) {
+        subrow = (NUM_PLAYER - 1) - player;
 	col = (w->cribBoard.numCols - 1) - col;
+    } else {
+        subrow = player;
+    }
+    row = row * NUM_PLAYER + subrow;
     x = ColPos (w, col);
     y = RowPos (w, row);
     cairo_save(cr);
-    XkwSetSource(cr, &w->cribBoard.pegColor);
+    XkwSetSource(cr, &w->cribBoard.pegColor[player]);
     cairo_translate(cr, x, y);
     cairo_move_to(cr, POLY_X0, POLY_Y0);
     cairo_line_to(cr, POLY_X1, POLY_Y1);
@@ -206,14 +221,11 @@ drawPeg (CribBoardWidget w, cairo_t *cr, int value)
 }
 
 static void
-drawHole (CribBoardWidget w, cairo_t *cr, int value)
+drawHole (CribBoardWidget w, cairo_t *cr, int row, int col)
 {
-    int	    row, col;
     double  x;
     double  y;
 
-    row = value / w->cribBoard.numCols;
-    col = value % w->cribBoard.numCols;
     x = ColPos (w, col);
     y = RowPos (w, row);
     cairo_save(cr);
@@ -225,30 +237,32 @@ drawHole (CribBoardWidget w, cairo_t *cr, int value)
 }
 
 static void
-drawTrack (CribBoardWidget w, cairo_t *cr, XRenderColor *color)
+drawTrack (CribBoardWidget w, cairo_t *cr, int player)
 {
     int row;
 
     cairo_save(cr);
-    XkwSetSource(cr, color);
+    XkwSetSourceInterp(cr, &w->cribBoard.pegColor[player], &w->ksimple.background);
     cairo_set_line_width(cr, trackWidth(w));
+    cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
 
-    for (row = 0; row < w->cribBoard.numRows; row += 2) {
-        double left_x = ColPos (w, 0);
-        double right_x = ColPos (w, w->cribBoard.numCols - 1);
-        double top_y = RowPos (w, row);
-        double bottom_y = RowPos (w, row + 1);
+    for (row = 0; row < w->cribBoard.numRows; row += (2 * NUM_PLAYER)) {
+        double left_x = ColPos (w, 0) - pegSize(w);
+        double right_x = ColPos (w, w->cribBoard.numCols - 1) + pegSize(w);
+        double top_y = RowPos (w, row + player);
+        double bottom_y = RowPos (w, row + (2 * NUM_PLAYER - player - 1));
+        double next_top_y = RowPos (w, row + (2 * NUM_PLAYER) + player);
 
         if (row == 0)
             cairo_move_to(cr, left_x, top_y);
 
-        cairo_line_to(cr, right_x + pegSize(w), top_y);
-        cairo_arc(cr, right_x + pegSize(w), (top_y + bottom_y) / 2, (bottom_y - top_y) / 2, -M_PI/2.0, M_PI/2.0);
+        cairo_line_to(cr, right_x, top_y);
+        cairo_arc(cr, right_x, (top_y + bottom_y) / 2, (bottom_y - top_y) / 2, -M_PI/2.0, M_PI/2.0);
 
-        if (row < w->cribBoard.numRows - 2) {
-            cairo_line_to(cr, left_x - pegSize(w), bottom_y);
+        if (row < w->cribBoard.numRows - (2 * NUM_PLAYER)) {
+            cairo_line_to(cr, left_x, bottom_y);
 
-            cairo_arc_negative(cr, left_x - pegSize(w), (bottom_y + RowPos(w, row+2)) / 2, (bottom_y - top_y) / 2, -M_PI/2.0, M_PI/2.0);
+            cairo_arc_negative(cr, left_x, (bottom_y + next_top_y) / 2, (next_top_y - bottom_y) / 2, -M_PI/2.0, M_PI/2.0);
         } else
             cairo_line_to(cr, left_x, bottom_y);
     }
@@ -260,7 +274,7 @@ static void
 Redisplay (Widget gw, XEvent *event, Region region)
 {
     CribBoardWidget w = (CribBoardWidget) gw;
-    int		    v;
+    int		    v, p, r, c;
     cairo_t	    *cr = XkwDrawBegin(gw, region);
     Dimension	    natural_width, natural_height;
 
@@ -274,17 +288,22 @@ Redisplay (Widget gw, XEvent *event, Region region)
 	width_ratio = height_ratio;
 
     double bw = borderWidth(w);
+    double bh = borderHeight(w);
 
     cairo_save(cr);
     cairo_scale(cr, width_ratio, width_ratio);
-    cairo_translate(cr, bw, bw);
+    cairo_translate(cr, bw, bh);
 
     (void) event;
-    drawTrack (w, cr, &w->cribBoard.pegColor);
-    for (v = 0; v < w->cribBoard.numRows * w->cribBoard.numCols; v++)
-	drawHole (w, cr, v);
-    for (v = 0; v < w->cribBoard.numPegs; v++)
-	drawPeg (w, cr, w->cribBoard.pegs[v]);
+    for (p = 0; p < NUM_PLAYER; p++)
+        drawTrack (w, cr, p);
+    for (r = 0; r < w->cribBoard.numRows; r++) {
+        for (c = 0; c < w->cribBoard.numCols; c++)
+            drawHole (w, cr, r, c);
+    }
+    for (p = 0; p < NUM_PLAYER; p++)
+        for (v = 0; v < NUM_PEG; v++)
+            drawPeg (w, cr, p, w->cribBoard.pegs[p][v]);
     cairo_restore(cr);
     XkwDrawEnd(gw, region, cr);
 }
@@ -296,12 +315,14 @@ SetValues (Widget gcur, Widget greq, Widget gnew, Arg *args, Cardinal *count)
 		    req = (CribBoardWidget) greq,
 		    new = (CribBoardWidget) gnew;
     Boolean	    redraw = FALSE;
+    int             p;
 
     (void) args;
     (void) count;
     (void) new;
-    if (!XkwColorEqual(&req->cribBoard.pegColor, &cur->cribBoard.pegColor))
-	redraw = TRUE;
+    for (p = 0; p < NUM_PLAYER; p++)
+        if (!XkwColorEqual(&req->cribBoard.pegColor[p], &cur->cribBoard.pegColor[p]))
+            redraw = TRUE;
     if (!XkwColorEqual(&req->cribBoard.holeColor, &cur->cribBoard.holeColor))
 	redraw = TRUE;
     return redraw;
@@ -358,13 +379,13 @@ CribBoardClassRec cribBoardClassRec = {
 WidgetClass cribBoardWidgetClass = (WidgetClass)&cribBoardClassRec;
 
 void
-XkwCribBoardSetPeg (Widget gw, int i, int v)
+XkwCribBoardSetPeg (Widget gw, int p, int i, int v)
 {
     CribBoardWidget w = (CribBoardWidget) gw;
 
-    if (0 <= i && i < w->cribBoard.numPegs && w->cribBoard.pegs[i] != v)
+    if (0 <= i && i < NUM_PEG && 0 <= p && p <= NUM_PLAYER && w->cribBoard.pegs[p][i] != v)
     {
-	w->cribBoard.pegs[i] = v;
+	w->cribBoard.pegs[p][i] = v;
 	Redisplay(gw, NULL, NULL);
     }
 }

--- a/kcribbage/CribBoard.h
+++ b/kcribbage/CribBoard.h
@@ -49,7 +49,10 @@
 
 /* define any special resource names here that are not in <X11/StringDefs.h> */
 
-#define XtNpegColor "pegColor"
+#define XtNpeg1Color "peg1Color"
+#define XtNpeg2Color "peg2Color"
+#define XtNpeg3Color "peg3Color"
+#define XtNpeg4Color "peg4Color"
 #define XtNholeColor "holeColor"
 #define XtNpegSize "pegSize"
 #define XtCPegSize "PegSize"
@@ -78,6 +81,6 @@ typedef struct _CribBoardRec*	    CribBoardWidget;
 extern WidgetClass cribBoardWidgetClass;
 
 void
-XkwCribBoardSetPeg (Widget gw, int i, int v);
+XkwCribBoardSetPeg (Widget gw, int i, int p, int v);
 
 #endif /* _CribBoard_h */

--- a/kcribbage/CribBoardP.h
+++ b/kcribbage/CribBoardP.h
@@ -47,17 +47,18 @@ typedef struct _CribBoardClassRec {
 
 extern CribBoardClassRec cribBoardClassRec;
 
+#define NUM_PEG         2
+#define NUM_PLAYER      2
+
 typedef struct {
     /* resources */
-    XRenderColor    pegColor;
+    XRenderColor    pegColor[NUM_PLAYER];
     XRenderColor    holeColor;
-    XRenderColor    trackColor;
-    int		    numPegs;
     int		    numCols;
     int		    numRows;
 
     /* private state */
-    int		    *pegs;
+    int             pegs[NUM_PLAYER][NUM_PEG];
 } CribBoardPart;
 
 typedef struct _CribBoardRec {

--- a/kcribbage/Cribbage.ad
+++ b/kcribbage/Cribbage.ad
@@ -7,8 +7,8 @@
 *tableScore.Foreground: #fffff0
 *table.Background: #337744
 *table.Foreground: #fffff0
-*playscore.pegColor: red
-*compscore.pegColor: blue
+*score.peg1Color: #ff1010
+*score.peg2Color: #1010ff
 
 *borderWidth: 0
 *SimpleMenu.borderWidth: 1
@@ -37,8 +37,10 @@
 *table.overlap: both
 
 *playname.label: Your score
+*playname.Foreground: #ff0000
 *playname.justify: left
 *compname.label: My score
+*compname.Foreground: #0000ff
 *compname.justify: left
 
 *playcrib.numRows: 1
@@ -96,9 +98,8 @@
 		} \
 		vertical { \
 			playname < +inf * -100% >\
-			playscore < +1 -1 * +1 -1 >\
+			score < +1 -1 * +1 -1 >\
 			compname < +inf * -100% >\
-			compscore < +1 -1 * +1 -1 >\
 			message < * +inf -inf > \
 		} \
 		-1 \

--- a/kcribbage/xt.c
+++ b/kcribbage/xt.c
@@ -61,9 +61,8 @@ static Widget	    table;
 static Widget       deckWidget;
 static Widget	    playcrib;
 static Widget	    playName;
-static Widget	    playScore;
 static Widget	    compName;
-static Widget	    compScore;
+static Widget	    scoreWidget;
 static Widget	    compcrib;
 static Widget	    tableScore;
 
@@ -232,9 +231,8 @@ UIInit (int argc, char **argv)
     XtAddCallback (table, XtNinputCallback, InputCallback, NULL);
     tableScore = XtCreateManagedWidget ("tableScore", klabelWidgetClass, layout, NULL, 0);
     playName = XtCreateManagedWidget ("playname", klabelWidgetClass, layout, NULL, 0);
-    playScore = XtCreateManagedWidget ("playscore", cribBoardWidgetClass, layout, NULL, 0);
+    scoreWidget = XtCreateManagedWidget ("score", cribBoardWidgetClass, layout, NULL, 0);
     compName = XtCreateManagedWidget ("compname", klabelWidgetClass, layout, NULL, 0);
-    compScore = XtCreateManagedWidget ("compscore", cribBoardWidgetClass, layout, NULL, 0);
     playcrib = XtCreateManagedWidget ("playcrib", cardsWidgetClass, layout, NULL, 0);
     XtAddCallback (playcrib, XtNinputCallback, InputCallback, NULL);
     compcrib = XtCreateManagedWidget ("compcrib", cardsWidgetClass, layout, NULL, 0);
@@ -263,22 +261,22 @@ static int compPegs[2];
 static int playPegs[2];
 
 static void
-resetPegs (Widget w, int *pegs)
+resetPegs (Widget w, int who, int *pegs)
 {
     int	    i;
 
     for (i = 0; i < 2; i++)
     {
 	pegs[i] = CribBoardUnset;
-	XkwCribBoardSetPeg (w, i, CribBoardUnset);
+	XkwCribBoardSetPeg (w, who, i, CribBoardUnset);
     }
 }
 
 void
 UIInitBoard (void)
 {
-    resetPegs (compScore, compPegs);
-    resetPegs (playScore, playPegs);
+    resetPegs (scoreWidget, PLAYER, playPegs);
+    resetPegs (scoreWidget, COMPUTER, compPegs);
     Message(compName, "My score");
     Message(playName, "Your score");
 }
@@ -490,7 +488,6 @@ UITableScore (int score, int n)
 void
 UIPrintPeg (int score, BOOLEAN on, int who)
 {
-    Widget	w;
     Widget      l;
     int		*pegs;
     int		i;
@@ -498,14 +495,12 @@ UIPrintPeg (int score, BOOLEAN on, int who)
 
     if (who == COMPUTER)
     {
-	w = compScore;
         l = compName;
 	pegs = compPegs;
         label = "My";
     }
     else
     {
-	w = playScore;
         l = playName;
 	pegs = playPegs;
         label = "Your";
@@ -530,7 +525,7 @@ UIPrintPeg (int score, BOOLEAN on, int who)
 	    i = 1;
     }
     pegs[i] = score;
-    XkwCribBoardSetPeg (w, i, score - 1);
+    XkwCribBoardSetPeg (scoreWidget, who, i, score - 1);
     Message(l, "%s score: %d", label, score);
 }
 


### PR DESCRIPTION
This makes the cribbage board score both players in the same widget,
instead of using one widget per player.

Signed-off-by: Keith Packard <keithp@keithp.com>