### PR TITLE
kcribbage: Show score explanations

### DIFF
--- a/kcribbage/support.c
+++ b/kcribbage/support.c
@@ -116,9 +116,13 @@ comphand(CARD *h, char *s)
 {
 	register int		j;
 
-	j = scorehand(h, turnover, CINHAND, strcmp(s, "crib") == 0, FALSE);
+	j = scorehand(h, turnover, CINHAND, strcmp(s, "crib") == 0, explain);
 	UIPrintHand (h, CINHAND, COMPUTER, FALSE);
-	msg("My %s scores %d", s, (j == 0 ? 19 : j));
+	msg("My %s scores %d%s%s%s",
+            s, (j == 0 ? 19 : j),
+            explain ? " (" : "",
+            explain ? expl : "",
+            explain ? ")" : "");
 	return chkscr(&cscore, j);
 }
 
@@ -265,4 +269,3 @@ makeknown( CARD *h, int n )
 	    known[ knownum++ ] = h[i];
 	}
 }
-

--- a/kcribbage/xt.c
+++ b/kcribbage/xt.c
@@ -185,7 +185,7 @@ XtResource resources[] = {
     { "animationSpeed", "AnimationSpeed", XtRInt, sizeof (int),
      offset(animationSpeed), XtRImmediate, (XtPointer) 500},
     { "explain", "Explain", XtRBoolean, sizeof (Boolean),
-     offset(explain), XtRImmediate, (XtPointer) False},
+     offset(explain), XtRImmediate, (XtPointer) True},
     { "quiet", "Quiet", XtRBoolean, sizeof (Boolean),
      offset(quiet), XtRImmediate, (XtPointer) False},
     { "random", "Random", XtRBoolean, sizeof (Boolean),
@@ -196,10 +196,11 @@ XrmOptionDescRec options[] = {
     { "-smallCards",	"*Cards.smallCards",	XrmoptionNoArg, "True", },
     { "-squareCards",	"*Cards.roundCards",	XrmoptionNoArg, "False", },
     { "-noanimate",	".animationSpeed",	XrmoptionNoArg, "0", },
-    { "-animationSpeed",	".animationSpeed",	XrmoptionSepArg, NULL, },
-    { "-explain",		".explain",		XrmoptionNoArg,	 "True", },
+    { "-animationSpeed",".animationSpeed",	XrmoptionSepArg, NULL, },
+    { "-explain",	".explain",		XrmoptionNoArg,	 "True", },
+    { "-noexplain",	".explain",		XrmoptionNoArg,	 "False", },
     { "-quiet",		".quiet",		XrmoptionNoArg,	 "True", },
-    { "-random",		".random",		XrmoptionNoArg,	 "True", },
+    { "-random",	".random",		XrmoptionNoArg,	 "True", },
 };
 
 void
@@ -311,7 +312,7 @@ UIWait (void)
 {
     XEvent  event;
 
-    UIMessage ("--More--", FALSE);
+    UIMessage ("--More--", TRUE);
     UIRefresh ();
     for (;;)
     {


### PR DESCRIPTION
The underlying cribbage code could generate explanations for hand
scoring, but it never bothered for the computer hand and they were
disabled by default for the player hand (shown when the player is
wrong).

I've enabled them by default and also display them for the computer
player as well.

Signed-off-by: Keith Packard <keithp@keithp.com>