### PR TITLE
Xkw: Don't move cards for horizontal scroll operations

### DIFF
--- a/Xkw/Hand.c
+++ b/Xkw/Hand.c
@@ -86,9 +86,15 @@ static char defaultTranslations[] =
     "<Btn4Up>:\n"
     "<Btn5Down>: zoomin()\n"
     "<Btn5Up>:\n"
-    "<BtnDown>: start()\n"
-    "<BtnMotion>: drag()\n"
-    "<BtnUp>: stop()";
+    "<Btn1Down>: start()\n"
+    "<Btn1Motion>: drag()\n"
+    "<Btn1Up>: stop()\n"
+    "<Btn2Down>: start()\n"
+    "<Btn2Motion>: drag()\n"
+    "<Btn2Up>: stop()\n"
+    "<Btn3Down>: start()\n"
+    "<Btn3Motion>: drag()\n"
+    "<Btn3Up>: stop()";
 
 #define SuperClass  ((KSimpleWidgetClass)&ksimpleClassRec)
 


### PR DESCRIPTION
Horizontal scroll events are delivered as button 6 and button 7. Xt
doesn't provide any way to name these events (PR filed), so instead of
adding translations to ignore these scroll events, add separate events
for buttons 1-3 instead of a catch-all button event that matches all
un-matched events.

Signed-off-by: Keith Packard <keithp@keithp.com>