### PR TITLE
Create a nested 'kgames' menu

### DIFF
--- a/Xkw/Message.c
+++ b/Xkw/Message.c
@@ -89,7 +89,10 @@ CardsRankName (CardsRank r)
 static char *
 MessageCard (char *s, CardsCardPtr c)
 {
-    sprintf (s, "%s of %ss", CardsRankName (c->rank), CardsSuitName (c->suit));
+    if (c->suit > CardsSpade || c->rank > CardsKing)
+        sprintf (s, "empty stack");
+    else
+        sprintf (s, "%s of %ss", CardsRankName (c->rank), CardsSuitName (c->suit));
     return s + strlen(s);
 }
 

--- a/kaces/kaces.desktop.in
+++ b/kaces/kaces.desktop.in
@@ -8,4 +8,4 @@ Icon=@ICONDIR@/kgames.svg
 StartupNotify=false
 Terminal=false
 Type=Application
-Categories=Game;CardGame
+Categories=Game;CardGame;Kgames

--- a/kcanfield/kcanfield.desktop.in
+++ b/kcanfield/kcanfield.desktop.in
@@ -8,4 +8,4 @@ Icon=@ICONDIR@/kgames.svg
 StartupNotify=false
 Terminal=false
 Type=Application
-Categories=Game;CardGame
+Categories=Game;CardGame;Kgames

--- a/kcribbage/kcribbage.desktop.in
+++ b/kcribbage/kcribbage.desktop.in
@@ -8,4 +8,4 @@ Icon=@ICONDIR@/kgames.svg
 StartupNotify=false
 Terminal=false
 Type=Application
-Categories=Game;CardGame
+Categories=Game;CardGame;Kgames

--- a/kdominos/kdominos.desktop.in
+++ b/kdominos/kdominos.desktop.in
@@ -8,4 +8,4 @@ Icon=@ICONDIR@/kdominos.svg
 StartupNotify=false
 Terminal=false
 Type=Application
-Categories=Game;CardGame
+Categories=Game;CardGame;Kgames

--- a/kgames.directory.in
+++ b/kgames.directory.in
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Encoding=UTF-8
+
+Icon=@ICONDIR@/kgames.svg
+
+Name=Kgames

--- a/kgames.menu.in
+++ b/kgames.menu.in
@@ -1,0 +1,18 @@
+<!DOCTYPE Menu PUBLIC "-//freedesktop//DTD Menu 1.0//EN"
+"http://www.freedesktop.org/standards/menu-spec/menu-1.1.dtd">
+<Menu>
+  <Name>Applications</Name>
+  <Menu>
+    <Name>Games</Name>
+    <Exclude>
+      <Category>Kgames</Category>
+    </Exclude>
+    <Menu>
+      <Name>KGames</Name>
+      <Directory>kgames.directory</Directory>
+      <Include>
+	<Category>Kgames</Category>
+      </Include>
+    </Menu>
+  </Menu>
+</Menu>

--- a/kklondike/kklondike.desktop.in
+++ b/kklondike/kklondike.desktop.in
@@ -8,4 +8,4 @@ Icon=@ICONDIR@/kgames.svg
 StartupNotify=false
 Terminal=false
 Type=Application
-Categories=Game;CardGame
+Categories=Game;CardGame;Kgames

--- a/kmcarlo/kmcarlo.desktop.in
+++ b/kmcarlo/kmcarlo.desktop.in
@@ -8,4 +8,4 @@ Icon=@ICONDIR@/kgames.svg
 StartupNotify=false
 Terminal=false
 Type=Application
-Categories=Game;CardGame
+Categories=Game;CardGame;Kgames

--- a/kmontana/kmontana.desktop.in
+++ b/kmontana/kmontana.desktop.in
@@ -8,4 +8,4 @@ Icon=@ICONDIR@/kgames.svg
 StartupNotify=false
 Terminal=false
 Type=Application
-Categories=Game;CardGame
+Categories=Game;CardGame;Kgames

--- a/kslyfox/kslyfox.desktop.in
+++ b/kslyfox/kslyfox.desktop.in
@@ -8,4 +8,4 @@ Icon=@ICONDIR@/kgames.svg
 StartupNotify=false
 Terminal=false
 Type=Application
-Categories=Game;CardGame
+Categories=Game;CardGame;Kgames

--- a/kspider/kspider.desktop.in
+++ b/kspider/kspider.desktop.in
@@ -8,4 +8,4 @@ Icon=@ICONDIR@/kgames.svg
 StartupNotify=false
 Terminal=false
 Type=Application
-Categories=Game;CardGame
+Categories=Game;CardGame;Kgames

--- a/ktabby/ktabby.desktop.in
+++ b/ktabby/ktabby.desktop.in
@@ -8,4 +8,4 @@ Icon=@ICONDIR@/kgames.svg
 StartupNotify=false
 Terminal=false
 Type=Application
-Categories=Game;CardGame
+Categories=Game;CardGame;Kgames

--- a/kthieves/kthieves.desktop.in
+++ b/kthieves/kthieves.desktop.in
@@ -8,4 +8,4 @@ Icon=@ICONDIR@/kgames.svg
 StartupNotify=false
 Terminal=false
 Type=Application
-Categories=Game;CardGame
+Categories=Game;CardGame;Kgames

--- a/ktowers/ktowers.desktop.in
+++ b/ktowers/ktowers.desktop.in
@@ -8,4 +8,4 @@ Icon=@ICONDIR@/kgames.svg
 StartupNotify=false
 Terminal=false
 Type=Application
-Categories=Game;CardGame
+Categories=Game;CardGame;Kgames

--- a/meson.build
+++ b/meson.build
@@ -52,6 +52,20 @@ svg_icon_dir = datadir / 'icons/hicolor/scalable/apps'
 
 desktop_dir = datadir / 'applications'
 
+menudir = get_option('menudir')
+if menudir == ''
+  if get_option('user-menu')
+    fs = import('fs')
+    xdg_config_dir = fs.expanduser('~/.config')
+    message('user-menu config_dir is ' + xdg_config_dir)
+  else
+    xdg_config_dir= sysconfdir / 'xdg'
+  endif
+  menudir = xdg_config_dir / 'menus/applications-merged'
+endif
+
+message('menudir is ' + menudir)
+
 conf_data = configuration_data()
 conf_data.set('KGAMES_VERSION', meson.project_version(),
 	      description: 'KGames version in unquoted string form.')
@@ -60,6 +74,7 @@ conf_data.set('KGAMES_VERSION_STRING',
 	      description: 'KGames version in quoted string form.')
 conf_data.set('BINDIR', prefix / bindir)
 conf_data.set('ICONDIR', prefix / svg_icon_dir)
+conf_data.set('MENUDIR', menudir)
 
 inc_dirs = ['.']
 
@@ -68,6 +83,18 @@ inc = include_directories(inc_dirs)
 configure_file(output : 'kgames.h',
 	       configuration: conf_data,
 	       install: false)
+
+configure_file(input: 'kgames.directory.in',
+	       output: '@BASENAME@',
+	       configuration: conf_data,
+	       install_dir : datadir / 'desktop-directories'
+	       )
+
+configure_file(input: 'kgames.menu.in',
+	       output: '@BASENAME@',
+	       configuration: conf_data,
+	       install_dir : menudir
+	       )
 
 subdir('Xkw')
 subdir('kaces')

--- a/meson.build
+++ b/meson.build
@@ -111,3 +111,5 @@ subdir('kthieves')
 subdir('ktowers')
 subdir('xmille')
 subdir('xreversi')
+
+meson.add_install_script('update-menus.sh')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,4 @@
+option('user-menu', type: 'boolean', value: true,
+       description: 'Install menu file only for current user')
+option('menudir', type: 'string',
+       description: 'Install directory for menu file')

--- a/update-menus.sh
+++ b/update-menus.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# Copyright © 2021 Keith Packard
+#
+# Permission to use, copy, modify, distribute, and sell this software and its
+# documentation for any purpose is hereby granted without fee, provided that
+# the above copyright notice appear in all copies and that both that copyright
+# notice and this permission notice appear in supporting documentation, and
+# that the name of the copyright holders not be used in advertising or
+# publicity pertaining to distribution of the software without specific,
+# written prior permission.  The copyright holders make no representations
+# about the suitability of this software for any purpose.  It is provided "as
+# is" without express or implied warranty.
+#
+# THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+# INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+# EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+# CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+# DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+# TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+if [ "$DISPLAY" != "" ] && command -v xdg-desktop-menu > /dev/null; then
+    xdg-desktop-menu forceupdate
+fi

--- a/xmille/xmille.desktop.in
+++ b/xmille/xmille.desktop.in
@@ -8,4 +8,4 @@ Icon=@ICONDIR@/xmille.svg
 StartupNotify=false
 Terminal=false
 Type=Application
-Categories=Game;CardGame
+Categories=Game;CardGame;Kgames

--- a/xreversi/xreversi.desktop.in
+++ b/xreversi/xreversi.desktop.in
@@ -8,4 +8,4 @@ Icon=@ICONDIR@/xreversi.svg
 StartupNotify=false
 Terminal=false
 Type=Application
-Categories=Game;BoardGame
+Categories=Game;BoardGame;Kgames


### PR DESCRIPTION
This adds .menu and .directory files so that all of the Kgames applications land in a Kgames sub-menu of the Games menu. Note that the default 'ninja install' does this for just the current user as there is no directory in /usr/local which can hold .menu files, the only global directory is /etc/xdg.